### PR TITLE
Handle missing id / name in PhotoDirectory

### DIFF
--- a/PhotoPicker/src/main/java/me/iwf/photopicker/entity/PhotoDirectory.java
+++ b/PhotoPicker/src/main/java/me/iwf/photopicker/entity/PhotoDirectory.java
@@ -1,8 +1,8 @@
 package me.iwf.photopicker.entity;
 
-import android.util.SparseBooleanArray;
+import android.text.TextUtils;
+
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -22,12 +22,35 @@ public class PhotoDirectory {
 
     PhotoDirectory directory = (PhotoDirectory) o;
 
-    if (!id.equals(directory.id)) return false;
-    return name.equals(directory.name);
+    boolean hasId = !TextUtils.isEmpty(id);
+    boolean otherHasId = !TextUtils.isEmpty(directory.id);
+
+    if (hasId && otherHasId) {
+      if (!TextUtils.equals(id, directory.id)) {
+        return false;
+      }
+
+      return TextUtils.equals(name, directory.name);
+    }
+
+    return false;
   }
 
   @Override public int hashCode() {
+    if (TextUtils.isEmpty(id)) {
+      if (TextUtils.isEmpty(name)) {
+        return 0;
+      }
+
+      return name.hashCode();
+    }
+
     int result = id.hashCode();
+
+    if (TextUtils.isEmpty(name)) {
+      return result;
+    }
+
     result = 31 * result + name.hashCode();
     return result;
   }


### PR DESCRIPTION
Seeing crash in the wild here:

```
java.lang.NullPointerException
at me.iwf.photopicker.entity.PhotoDirectory.equals (PhotoDirectory.java:25)
at java.util.ArrayList.contains (ArrayList.java:339)
at me.iwf.photopicker.utils.MediaStoreHelper$PhotoDirLoaderCallbacks.onLoadFinished (MediaStoreHelper.java:74)
at me.iwf.photopicker.utils.MediaStoreHelper$PhotoDirLoaderCallbacks.onLoadFinished (MediaStoreHelper.java:37)
at android.support.v4.app.LoaderManagerImpl$LoaderInfo.callOnLoadFinished (LoaderManager.java:476)
at android.support.v4.app.LoaderManagerImpl$LoaderInfo.onLoadComplete (LoaderManager.java:444)
at android.support.v4.content.Loader.deliverResult (Loader.java:126)
at android.support.v4.content.CursorLoader.deliverResult (CursorLoader.java:105)
at android.support.v4.content.CursorLoader.deliverResult (CursorLoader.java:37)
at android.support.v4.content.AsyncTaskLoader.dispatchOnLoadComplete (AsyncTaskLoader.java:249)
at android.support.v4.content.AsyncTaskLoader$LoadTask.onPostExecute (AsyncTaskLoader.java:77)
at android.support.v4.content.ModernAsyncTask.finish (ModernAsyncTask.java:466)
at android.support.v4.content.ModernAsyncTask.access$400 (ModernAsyncTask.java:48)
at android.support.v4.content.ModernAsyncTask$InternalHandler.handleMessage (ModernAsyncTask.java:483)
at android.os.Handler.dispatchMessage (Handler.java:102)
at android.os.Looper.loop (Looper.java:136)
at android.app.ActivityThread.main (ActivityThread.java:5584)
at java.lang.reflect.Method.invokeNative (Unknown source)
at java.lang.reflect.Method.invoke (Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:1268)
at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1084)
at dalvik.system.NativeStart.main (Unknown source)
```