### PR TITLE
Handle null directories in onDetach

### DIFF
--- a/PhotoPicker/src/main/java/me/iwf/photopicker/fragment/PhotoPickerFragment.java
+++ b/PhotoPicker/src/main/java/me/iwf/photopicker/fragment/PhotoPickerFragment.java
@@ -232,6 +232,10 @@ public class PhotoPickerFragment extends Fragment {
   @Override public void onDetach() {
     super.onDetach();
 
+    if (directories == null) {
+      return;
+    }
+
     for (PhotoDirectory directory : directories) {
       directory.getPhotoPaths().clear();
       directory.getPhotos().clear();


### PR DESCRIPTION
- Seeing bug in wild:

java.lang.NullPointerException: Attempt to invoke interface method 'java.util.Iterator
java.util.List.iterator()' on a null object reference

at me.iwf.photopicker.fragment.PhotoPickerFragment.onDetach (PhotoPickerFragment.java:235)
at android.support.v4.app.FragmentManagerImpl.moveToState (FragmentManager.java:1202)
at android.support.v4.app.FragmentManagerImpl.removeFragment (FragmentManager.java:1349)
at android.support.v4.app.BackStackRecord.run (BackStackRecord.java:699)
at android.support.v4.app.FragmentManagerImpl.execPendingActions (FragmentManager.java:1617)
at android.support.v4.app.FragmentManagerImpl.executePendingTransactions (FragmentManager.java:570)
at me.iwf.photopicker.PhotoPickerActivity.onCreate (PhotoPickerActivity.java:75)