### PR TITLE
Fix crash in galleryAddPic

### DIFF
--- a/PhotoPicker/src/main/java/me/iwf/photopicker/utils/ImageCaptureManager.java
+++ b/PhotoPicker/src/main/java/me/iwf/photopicker/utils/ImageCaptureManager.java
@@ -76,7 +76,14 @@ public class ImageCaptureManager {
       return;
     }
 
-    File f = new File(mCurrentPhotoPath);
+    final File f;
+
+    try {
+      f = new File(mCurrentPhotoPath);
+    } catch (Exception e) {
+      return;
+    }
+
     Uri contentUri = Uri.fromFile(f);
     mediaScanIntent.setData(contentUri);
     mContext.sendBroadcast(mediaScanIntent);


### PR DESCRIPTION
java.lang.NullPointerException

at java.io.File.fixSlashes (File.java:185)
at java.io.File.<init> (File.java:134)
at me.iwf.photopicker.utils.ImageCaptureManager.galleryAddPic
(ImageCaptureManager.java:73)
at me.iwf.photopicker.fragment.PhotoPickerFragment.onActivityResult
(PhotoPickerFragment.java:200)