### PR TITLE
查看图片详情时，确定按钮改为一直可点击，若列表有选择图片，回传选择的图片，若列表没有选择图片默认把当前图片传回去

### DIFF
--- a/PhotoPicker/src/main/java/me/iwf/photopicker/PhotoPickerActivity.java
+++ b/PhotoPicker/src/main/java/me/iwf/photopicker/PhotoPickerActivity.java
@@ -102,13 +102,37 @@ public class PhotoPickerActivity extends AppCompatActivity {
               LENGTH_LONG).show();
           return false;
         }
-        menuDoneItem.setTitle(getString(R.string.__picker_done_with_count, selectedItemCount, maxCount));
+        if(maxCount > 1){
+          menuDoneItem.setTitle(getString(R.string.__picker_done_with_count, selectedItemCount, maxCount));
+        }else {
+          menuDoneItem.setTitle(getString(R.string.__picker_done));
+        }
         return true;
       }
     });
 
   }
 
+  //刷新右上角按钮文案
+  public void updateTitleDoneItem(){
+    if(menuIsInflated){
+      if(pickerFragment != null && pickerFragment.isResumed()){
+        List<String> photos = pickerFragment.getPhotoGridAdapter().getSelectedPhotos();
+        int size = photos == null ? 0 : photos.size();
+        menuDoneItem.setEnabled(size > 0);
+        if(maxCount > 1){
+          menuDoneItem.setTitle(getString(R.string.__picker_done_with_count, size, maxCount));
+        }else {
+          menuDoneItem.setTitle(getString(R.string.__picker_done));
+        }
+
+      }else if(imagePagerFragment != null && imagePagerFragment.isResumed()){
+        //预览界面 完成总是可点的，没选就把默认当前图片
+        menuDoneItem.setEnabled(true);
+      }
+
+    }
+  }
 
   /**
    * Overriding this method allows us to run our exit animation first, then exiting
@@ -165,10 +189,23 @@ public class PhotoPickerActivity extends AppCompatActivity {
 
     if (item.getItemId() == R.id.done) {
       Intent intent = new Intent();
-      ArrayList<String> selectedPhotos = pickerFragment.getPhotoGridAdapter().getSelectedPhotoPaths();
-      intent.putStringArrayListExtra(KEY_SELECTED_PHOTOS, selectedPhotos);
-      setResult(RESULT_OK, intent);
-      finish();
+      ArrayList<String> selectedPhotos = null;
+      if(pickerFragment != null){
+        selectedPhotos = pickerFragment.getPhotoGridAdapter().getSelectedPhotoPaths();
+      }
+      //当在列表没有选择图片，又在详情界面时默认选择当前图片
+      if(selectedPhotos.size() <= 0){
+        if(imagePagerFragment != null && imagePagerFragment.isResumed()){
+          // 预览界面
+          selectedPhotos = imagePagerFragment.getCurrentPath();
+        }
+      }
+      if(selectedPhotos != null && selectedPhotos.size() > 0){
+        intent.putStringArrayListExtra(KEY_SELECTED_PHOTOS, selectedPhotos);
+        setResult(RESULT_OK, intent);
+        finish();
+      }
+
       return true;
     }
 

--- a/PhotoPicker/src/main/java/me/iwf/photopicker/fragment/ImagePagerFragment.java
+++ b/PhotoPicker/src/main/java/me/iwf/photopicker/fragment/ImagePagerFragment.java
@@ -12,14 +12,18 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
+
 import com.bumptech.glide.Glide;
 import com.nineoldandroids.animation.Animator;
 import com.nineoldandroids.animation.ObjectAnimator;
 import com.nineoldandroids.view.ViewHelper;
 import com.nineoldandroids.view.ViewPropertyAnimator;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import me.iwf.photopicker.PhotoPickerActivity;
 import me.iwf.photopicker.R;
 import me.iwf.photopicker.adapter.PhotoPagerAdapter;
 
@@ -83,6 +87,14 @@ public class ImagePagerFragment extends Fragment {
     return f;
   }
 
+  @Override
+  public void onResume() {
+    super.onResume();
+    if(getActivity() instanceof PhotoPickerActivity){
+      PhotoPickerActivity photoPickerActivity = (PhotoPickerActivity) getActivity();
+      photoPickerActivity.updateTitleDoneItem();
+    }
+  }
 
   public void setPhotos(List<String> paths, int currentItem) {
     this.paths.clear();
@@ -288,6 +300,16 @@ public class ImagePagerFragment extends Fragment {
 
   public ArrayList<String> getPaths() {
     return paths;
+  }
+
+
+  public ArrayList<String> getCurrentPath(){
+    ArrayList<String> list = new ArrayList<>();
+    int position = mViewPager.getCurrentItem();
+    if(paths != null && paths.size() > position){
+      list.add(paths.get(position));
+    }
+    return list;
   }
 
 

--- a/PhotoPicker/src/main/java/me/iwf/photopicker/fragment/PhotoPickerFragment.java
+++ b/PhotoPicker/src/main/java/me/iwf/photopicker/fragment/PhotoPickerFragment.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import me.iwf.photopicker.PhotoPicker;
 import me.iwf.photopicker.PhotoPickerActivity;
 import me.iwf.photopicker.R;
 import me.iwf.photopicker.adapter.PhotoGridAdapter;
@@ -123,6 +122,15 @@ public class PhotoPickerFragment extends Fragment {
         });
 
     captureManager = new ImageCaptureManager(getActivity());
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    if(getActivity() instanceof PhotoPickerActivity){
+      PhotoPickerActivity photoPickerActivity = (PhotoPickerActivity) getActivity();
+      photoPickerActivity.updateTitleDoneItem();
+    }
   }
 
 


### PR DESCRIPTION
当很多图片是大量文字的时候，在列表界面根本就看不清，所以需要在图片详情界面确定，
所以感觉这个功能很必要！！提交的代码已充分自测，暂时没发现引入新bug哈哈