### PR TITLE
update glide to 4.8.0, support lib 28.0.0, crashlytics 2.9.5

### DIFF
--- a/PhotoPicker/build.gradle
+++ b/PhotoPicker/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation "com.android.support:design:$supportLibVersion"
   implementation "com.android.support:recyclerview-v7:$supportLibVersion"
   implementation "com.android.support:support-annotations:$supportLibVersion"
-  implementation "com.github.bumptech.glide:glide:4.1.1"
+  implementation "com.github.bumptech.glide:glide:4.8.0"
 }
 
 //apply plugin: 'com.novoda.bintray-release'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        supportLibVersion = "27.1.1"
+        supportLibVersion = "28.0.0"
     }
     repositories {
         jcenter()

--- a/photopickerdemo/build.gradle
+++ b/photopickerdemo/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation "com.android.support:design:$supportLibVersion"
     implementation "com.android.support:recyclerview-v7:$supportLibVersion"
     implementation "com.android.support:support-annotations:$supportLibVersion"
-    implementation "com.github.bumptech.glide:glide:4.1.1"
+    implementation "com.github.bumptech.glide:glide:4.8.0"
 
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.4'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.5'
 }


### PR DESCRIPTION
Fix error "No virtual method into", test in android 8.1(real device)