### PR TITLE
Fix the photo grid invisible after activity restart.

### DIFF
--- a/PhotoPicker/src/main/java/me/iwf/photopicker/utils/MediaStoreHelper.java
+++ b/PhotoPicker/src/main/java/me/iwf/photopicker/utils/MediaStoreHelper.java
@@ -55,6 +55,8 @@ public class MediaStoreHelper {
       photoDirectoryAll.setName(context.getString(R.string.__picker_all_image));
       photoDirectoryAll.setId("ALL");
 
+      data.moveToFirst();
+
       while (data.moveToNext()) {
 
         int imageId  = data.getInt(data.getColumnIndexOrThrow(_ID));


### PR DESCRIPTION
修正了从其他页面返回图片选择器时图片全部消失的的问题 

FIX #273 #272 #263 #247